### PR TITLE
Fix FileType autocmd for norg

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -194,7 +194,7 @@ vim.api.nvim_create_autocmd('FileType', {
 })
 
 -- Norg
-vim.api.nvim_create_autocmd('Filetype', {
+vim.api.nvim_create_autocmd('FileType', {
   pattern = 'norg',
   callback = function()
     vim.keymap.set('n', '<CR>', '<Plug>(neorg.esupports.hop.hop-link)', { buffer = true })


### PR DESCRIPTION
## Summary
- fix autocmd event name casing in `init.lua` so norg keymap triggers

## Testing
- `nvim --headless -c 'q'` *(fails: `nvim` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686aefd60300832fa16f6e82fb531156